### PR TITLE
feat(agents): add private hermes channels with permission overrides

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,8 +2,8 @@
 experimental = true
 
 [tools]
-terraform = "1.15.3"
-trivy = "0.69.1"
-terraform-docs = "0.24.0"
-pre-commit = "4.6.0"
-tflint = "0.62.1"
+"aqua:hashicorp/terraform" = "1.15.3"
+"aqua:aquasecurity/trivy" = "0.70.0"
+"aqua:terraform-docs/terraform-docs" = "0.24.0"
+"aqua:pre-commit/pre-commit" = "4.6.0"
+"aqua:terraform-linters/tflint" = "0.62.1"

--- a/data/categories/agents.yaml
+++ b/data/categories/agents.yaml
@@ -8,3 +8,7 @@ spec:
   displayName: 🧑‍💻・AGENTS
   channels:
     - hermes
+    - hermes-crowlex
+    - hermes-techninik
+    - hermes-jazzlyn
+    - hermes-tyriis

--- a/data/channels/hermes-crowlex.yaml
+++ b/data/channels/hermes-crowlex.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: terraform.techtales.io/v1alpha1
+kind: DiscordTextChannel
+metadata:
+  name: hermes-crowlex
+  namespace: techtales.io
+spec:
+  displayName: 🤖・crowlex
+  owner: crowlex
+  syncPermissionsWithCategory: false

--- a/data/channels/hermes-jazzlyn.yaml
+++ b/data/channels/hermes-jazzlyn.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: terraform.techtales.io/v1alpha1
+kind: DiscordTextChannel
+metadata:
+  name: hermes-jazzlyn
+  namespace: techtales.io
+spec:
+  displayName: 🤖・jazzlyn
+  owner: jazzlyn
+  syncPermissionsWithCategory: false

--- a/data/channels/hermes-techninik.yaml
+++ b/data/channels/hermes-techninik.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: terraform.techtales.io/v1alpha1
+kind: DiscordTextChannel
+metadata:
+  name: hermes-techninik
+  namespace: techtales.io
+spec:
+  displayName: 🤖・techinik
+  owner: techinik
+  syncPermissionsWithCategory: false

--- a/data/channels/hermes-tyriis.yaml
+++ b/data/channels/hermes-tyriis.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: terraform.techtales.io/v1alpha1
+kind: DiscordTextChannel
+metadata:
+  name: hermes-tyriis
+  namespace: techtales.io
+spec:
+  displayName: 🤖・tyriis
+  owner: tyriis
+  syncPermissionsWithCategory: false

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -11,21 +11,22 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.14.3 |
-| <a name="requirement_discord"></a> [discord](#requirement\_discord) | 2.2.2 |
-| <a name="requirement_vault"></a> [vault](#requirement\_vault) | 5.3.0 |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.3 |
+| <a name="requirement_discord"></a> [discord](#requirement\_discord) | 2.6.0 |
+| <a name="requirement_vault"></a> [vault](#requirement\_vault) | 5.9.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_vault"></a> [vault](#provider\_vault) | 5.3.0 |
+| ---- | ------- |
+| <a name="provider_discord"></a> [discord](#provider\_discord) | 2.6.0 |
+| <a name="provider_vault"></a> [vault](#provider\_vault) | 5.9.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_assets"></a> [assets](#module\_assets) | ../modules/assets/png-loader | n/a |
 | <a name="module_category"></a> [category](#module\_category) | ../modules/discord/category | n/a |
 | <a name="module_channel"></a> [channel](#module\_channel) | ../modules/discord/channel | n/a |
@@ -36,9 +37,14 @@
 ## Resources
 
 | Name | Type |
-|------|------|
-| [vault_kv_secret_v2.terraform_discord](https://registry.terraform.io/providers/hashicorp/vault/5.3.0/docs/resources/kv_secret_v2) | resource |
-| [vault_generic_secret.terraform_discord](https://registry.terraform.io/providers/hashicorp/vault/5.3.0/docs/data-sources/generic_secret) | data source |
+| ---- | ---- |
+| [discord_channel_permission.allow_admin](https://registry.terraform.io/providers/Lucky3028/discord/2.6.0/docs/resources/channel_permission) | resource |
+| [discord_channel_permission.allow_hermes](https://registry.terraform.io/providers/Lucky3028/discord/2.6.0/docs/resources/channel_permission) | resource |
+| [discord_channel_permission.allow_owner](https://registry.terraform.io/providers/Lucky3028/discord/2.6.0/docs/resources/channel_permission) | resource |
+| [discord_channel_permission.deny_everyone](https://registry.terraform.io/providers/Lucky3028/discord/2.6.0/docs/resources/channel_permission) | resource |
+| [vault_kv_secret_v2.terraform_discord](https://registry.terraform.io/providers/hashicorp/vault/5.9.0/docs/resources/kv_secret_v2) | resource |
+| [discord_role.admin](https://registry.terraform.io/providers/Lucky3028/discord/2.6.0/docs/data-sources/role) | data source |
+| [vault_generic_secret.terraform_discord](https://registry.terraform.io/providers/hashicorp/vault/5.9.0/docs/data-sources/generic_secret) | data source |
 
 ## Inputs
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,3 +1,8 @@
+data "discord_role" "admin" {
+  server_id = module.server["techtales.io"].data.id
+  name      = "admin"
+}
+
 locals {
   # Create a map of categories, each containing a map of channels
   category_channel_map = {
@@ -10,4 +15,32 @@ locals {
 
   # Flatten the nested map into a single map of channel_name to category_data
   channel_to_category = merge(values(local.category_channel_map)...)
+
+  # Discord user snowflake IDs for private channel access control
+  user_ids = {
+    crowlex  = "1028665851588657263"
+    techinik = "1381694540964040714"
+    jazzlyn  = "777140685118898176"
+    tyriis   = "713481031768080388"
+    hermes   = "1504207550097260716"
+  }
+
+  # @everyone role ID is always the server/guild ID in Discord
+  everyone_role_id = module.server["techtales.io"].data.id
+  admin_role_id    = data.discord_role.admin.id
+
+  # Permission bitmasks used:
+  # VIEW_CHANNEL (0x400)        = 1024
+  # SEND_MESSAGES (0x800)       = 2048
+  # READ_MESSAGE_HISTORY (0x10000) = 65536
+  # read + write + history = 1024 + 2048 + 65536 = 68608
+  perms_read_write_history = "68608"
+  perms_view_channel       = "1024"
+
+  # Filter channels that have an owner (private per-user channels)
+  owner_channels = {
+    for ch_name, ch_data in module.yaml.data.channels :
+    ch_name => ch_data
+    if try(ch_data.spec.owner, null) != null
+  }
 }

--- a/terraform/permissions.tf
+++ b/terraform/permissions.tf
@@ -1,0 +1,42 @@
+# Channel permission overrides for private Hermes agent channels
+# Each owner channel gets 4 permission entries:
+#   1. Deny @everyone VIEW_CHANNEL
+#   2. Allow the channel owner read/write
+#   3. Allow @admin role read/write
+#   4. Allow Hermes bot read/write
+
+resource "discord_channel_permission" "deny_everyone" {
+  for_each     = local.owner_channels
+  channel_id   = module.channel[each.key].data[0].id
+  type         = "role"
+  overwrite_id = local.everyone_role_id
+  deny         = tonumber(local.perms_view_channel)
+  allow        = 0
+}
+
+resource "discord_channel_permission" "allow_owner" {
+  for_each     = local.owner_channels
+  channel_id   = module.channel[each.key].data[0].id
+  type         = "user"
+  overwrite_id = local.user_ids[each.value.spec.owner]
+  deny         = 0
+  allow        = tonumber(local.perms_read_write_history)
+}
+
+resource "discord_channel_permission" "allow_admin" {
+  for_each     = local.owner_channels
+  channel_id   = module.channel[each.key].data[0].id
+  type         = "role"
+  overwrite_id = local.admin_role_id
+  deny         = 0
+  allow        = tonumber(local.perms_read_write_history)
+}
+
+resource "discord_channel_permission" "allow_hermes" {
+  for_each     = local.owner_channels
+  channel_id   = module.channel[each.key].data[0].id
+  type         = "user"
+  overwrite_id = local.user_ids["hermes"]
+  deny         = 0
+  allow        = tonumber(local.perms_read_write_history)
+}


### PR DESCRIPTION
adds 4 private per-user hermes ai assistant channels under the agents category:

- hermes-crowlex
- hermes-techinik
- hermes-jazzlyn
- hermes-tyriis

each channel is visible only to the owner, @admin role, and the hermes bot via discord_channel_permission resources.