### PR TITLE
feat(hermes): rename agent channel tyriis to euphoria

### DIFF
--- a/data/categories/agents.yaml
+++ b/data/categories/agents.yaml
@@ -11,4 +11,4 @@ spec:
     - hermes-crowlex
     - hermes-techninik
     - hermes-jazzlyn
-    - hermes-tyriis
+    - euphoria

--- a/data/channels/euphoria.yaml
+++ b/data/channels/euphoria.yaml
@@ -2,9 +2,9 @@
 apiVersion: terraform.techtales.io/v1alpha1
 kind: DiscordTextChannel
 metadata:
-  name: hermes-tyriis
+  name: euphoria
   namespace: techtales.io
 spec:
-  displayName: 🤖・tyriis
+  displayName: 🤖・euphoria
   owner: tyriis
   syncPermissionsWithCategory: false

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -13,7 +13,7 @@
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.5 |
-| <a name="requirement_discord"></a> [discord](#requirement\_discord) | 2.6.0 |
+| <a name="requirement_discord"></a> [discord](#requirement\_discord) | 2.7.0 |
 | <a name="requirement_vault"></a> [vault](#requirement\_vault) | 5.9.0 |
 
 ## Providers
@@ -38,11 +38,11 @@
 
 | Name | Type |
 | ---- | ---- |
-| [discord_channel_permission.allow_admin](https://registry.terraform.io/providers/Lucky3028/discord/2.6.0/docs/resources/channel_permission) | resource |
-| [discord_channel_permission.allow_euphoria](https://registry.terraform.io/providers/Lucky3028/discord/2.6.0/docs/resources/channel_permission) | resource |
-| [discord_channel_permission.allow_hermes](https://registry.terraform.io/providers/Lucky3028/discord/2.6.0/docs/resources/channel_permission) | resource |
-| [discord_channel_permission.allow_owner](https://registry.terraform.io/providers/Lucky3028/discord/2.6.0/docs/resources/channel_permission) | resource |
-| [discord_channel_permission.deny_everyone](https://registry.terraform.io/providers/Lucky3028/discord/2.6.0/docs/resources/channel_permission) | resource |
+| [discord_channel_permission.allow_admin](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
+| [discord_channel_permission.allow_euphoria](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
+| [discord_channel_permission.allow_hermes](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
+| [discord_channel_permission.allow_owner](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
+| [discord_channel_permission.deny_everyone](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
 | [vault_kv_secret_v2.terraform_discord](https://registry.terraform.io/providers/hashicorp/vault/5.9.0/docs/resources/kv_secret_v2) | resource |
 | [vault_generic_secret.terraform_discord](https://registry.terraform.io/providers/hashicorp/vault/5.9.0/docs/data-sources/generic_secret) | data source |
 

--- a/terraform/moved.tf
+++ b/terraform/moved.tf
@@ -157,3 +157,29 @@ moved {
   from = discord_webhook.talos_flux_flux_system
   to   = module.webhook["flux-system"].discord_webhook.main
 }
+
+# hermes-tyriis -> euphoria channel rename
+moved {
+  from = module.channel["hermes-tyriis"].discord_text_channel.main[0]
+  to   = module.channel["euphoria"].discord_text_channel.main[0]
+}
+
+moved {
+  from = discord_channel_permission.deny_everyone["hermes-tyriis"]
+  to   = discord_channel_permission.deny_everyone["euphoria"]
+}
+
+moved {
+  from = discord_channel_permission.allow_owner["hermes-tyriis"]
+  to   = discord_channel_permission.allow_owner["euphoria"]
+}
+
+moved {
+  from = discord_channel_permission.allow_admin["hermes-tyriis"]
+  to   = discord_channel_permission.allow_admin["euphoria"]
+}
+
+moved {
+  from = discord_channel_permission.allow_hermes["hermes-tyriis"]
+  to   = discord_channel_permission.allow_hermes["euphoria"]
+}

--- a/terraform/permissions.tf
+++ b/terraform/permissions.tf
@@ -42,7 +42,7 @@ resource "discord_channel_permission" "allow_hermes" {
 }
 
 resource "discord_channel_permission" "allow_euphoria" {
-  channel_id   = module.channel["hermes-tyriis"].data[0].id
+  channel_id   = module.channel["euphoria"].data[0].id
   type         = "user"
   overwrite_id = local.user_ids["euphoria"]
   deny         = 0


### PR DESCRIPTION
Renames the Hermes agent channel from `tyriis` to `euphoria`.

**Changes:**
- Deleted `data/channels/hermes-tyriis.yaml`
- Created `data/channels/euphoria.yaml` (owner: `tyriis`)
- Updated `data/categories/agents.yaml` reference
- Updated `terraform/permissions.tf` channel reference

Ref: tyriis/home-ops#8831