### PR TITLE
feat(hermes): rename crowlex channel to titan-ai

### DIFF
--- a/data/categories/agents.yaml
+++ b/data/categories/agents.yaml
@@ -8,7 +8,7 @@ spec:
   displayName: 🧑‍💻・AGENTS
   channels:
     - hermes
-    - hermes-crowlex
+    - titan-ai
     - hermes-techninik
     - moira
     - euphoria

--- a/data/channels/titan-ai.yaml
+++ b/data/channels/titan-ai.yaml
@@ -2,9 +2,9 @@
 apiVersion: terraform.techtales.io/v1alpha1
 kind: DiscordTextChannel
 metadata:
-  name: hermes-crowlex
+  name: titan-ai
   namespace: techtales.io
 spec:
-  displayName: 🤖・crowlex
+  displayName: 🤖・titan-ai
   owner: crowlex
   syncPermissionsWithCategory: false

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -43,6 +43,7 @@
 | [discord_channel_permission.allow_hermes](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
 | [discord_channel_permission.allow_moira](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
 | [discord_channel_permission.allow_owner](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
+| [discord_channel_permission.allow_titan_ai](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
 | [discord_channel_permission.deny_everyone](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
 | [vault_kv_secret_v2.terraform_discord](https://registry.terraform.io/providers/hashicorp/vault/5.9.0/docs/resources/kv_secret_v2) | resource |
 | [vault_generic_secret.terraform_discord](https://registry.terraform.io/providers/hashicorp/vault/5.9.0/docs/data-sources/generic_secret) | data source |

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -20,6 +20,7 @@ locals {
     hermes   = "1504207550097260716"
     euphoria = "1510342663701004318"
     moira    = "1512927492577689620"
+    titan-ai = "1513107170533703730"
   }
 
   # @everyone role ID is always the server/guild ID in Discord

--- a/terraform/moved.tf
+++ b/terraform/moved.tf
@@ -209,3 +209,29 @@ moved {
   from = discord_channel_permission.allow_hermes["hermes-jazzlyn"]
   to   = discord_channel_permission.allow_hermes["moira"]
 }
+
+# hermes-crowlex -> titan-ai channel rename
+moved {
+  from = module.channel["hermes-crowlex"].discord_text_channel.main[0]
+  to   = module.channel["titan-ai"].discord_text_channel.main[0]
+}
+
+moved {
+  from = discord_channel_permission.deny_everyone["hermes-crowlex"]
+  to   = discord_channel_permission.deny_everyone["titan-ai"]
+}
+
+moved {
+  from = discord_channel_permission.allow_owner["hermes-crowlex"]
+  to   = discord_channel_permission.allow_owner["titan-ai"]
+}
+
+moved {
+  from = discord_channel_permission.allow_admin["hermes-crowlex"]
+  to   = discord_channel_permission.allow_admin["titan-ai"]
+}
+
+moved {
+  from = discord_channel_permission.allow_hermes["hermes-crowlex"]
+  to   = discord_channel_permission.allow_hermes["titan-ai"]
+}

--- a/terraform/permissions.tf
+++ b/terraform/permissions.tf
@@ -56,3 +56,11 @@ resource "discord_channel_permission" "allow_moira" {
   deny         = 0
   allow        = tonumber(local.perms_read_write_history)
 }
+
+resource "discord_channel_permission" "allow_titan_ai" {
+  channel_id   = module.channel["titan-ai"].data[0].id
+  type         = "user"
+  overwrite_id = local.user_ids["titan-ai"]
+  deny         = 0
+  allow        = tonumber(local.perms_read_write_history)
+}


### PR DESCRIPTION
Renames the `hermes-crowlex` channel to `titan-ai`, following the same pattern as the moira and euphoria renames.

Closes tyriis/home-ops#8831