### PR TITLE
feat: add nova private channel for techinik

### DIFF
--- a/data/categories/agents.yaml
+++ b/data/categories/agents.yaml
@@ -12,3 +12,4 @@ spec:
     - hermes-techninik
     - moira
     - euphoria
+    - nova

--- a/data/channels/nova.yaml
+++ b/data/channels/nova.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: terraform.techtales.io/v1alpha1
+kind: DiscordTextChannel
+metadata:
+  name: nova
+  namespace: techtales.io
+spec:
+  displayName: 🤖・nova
+  owner: techinik
+  syncPermissionsWithCategory: false


### PR DESCRIPTION
Adds a new private per-user channel `nova` for techinik in the `agents` category, following the same pattern as `titan-ai`, `euphoria`, and `moira`.