### PR TITLE
feat(hermes): add nova private channel for techinik

### DIFF
--- a/data/categories/agents.yaml
+++ b/data/categories/agents.yaml
@@ -8,7 +8,7 @@ spec:
   displayName: 🧑‍💻・AGENTS
   channels:
     - hermes
-    - hermes-crowlex
-    - hermes-techninik
+    - titan-ai
+    - nova
     - moira
     - euphoria

--- a/data/channels/nova.yaml
+++ b/data/channels/nova.yaml
@@ -2,9 +2,9 @@
 apiVersion: terraform.techtales.io/v1alpha1
 kind: DiscordTextChannel
 metadata:
-  name: hermes-crowlex
+  name: nova
   namespace: techtales.io
 spec:
-  displayName: 🤖・crowlex
-  owner: crowlex
+  displayName: 🤖・nova
+  owner: techinik
   syncPermissionsWithCategory: false

--- a/data/channels/titan-ai.yaml
+++ b/data/channels/titan-ai.yaml
@@ -2,9 +2,9 @@
 apiVersion: terraform.techtales.io/v1alpha1
 kind: DiscordTextChannel
 metadata:
-  name: hermes-techninik
+  name: titan-ai
   namespace: techtales.io
 spec:
-  displayName: 🤖・techinik
-  owner: techinik
+  displayName: 🤖・titan-ai
+  owner: crowlex
   syncPermissionsWithCategory: false

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -42,7 +42,9 @@
 | [discord_channel_permission.allow_euphoria](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
 | [discord_channel_permission.allow_hermes](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
 | [discord_channel_permission.allow_moira](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
+| [discord_channel_permission.allow_nova](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
 | [discord_channel_permission.allow_owner](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
+| [discord_channel_permission.allow_titan_ai](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
 | [discord_channel_permission.deny_everyone](https://registry.terraform.io/providers/Lucky3028/discord/2.7.0/docs/resources/channel_permission) | resource |
 | [vault_kv_secret_v2.terraform_discord](https://registry.terraform.io/providers/hashicorp/vault/5.9.0/docs/resources/kv_secret_v2) | resource |
 | [vault_generic_secret.terraform_discord](https://registry.terraform.io/providers/hashicorp/vault/5.9.0/docs/data-sources/generic_secret) | data source |

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -20,6 +20,8 @@ locals {
     hermes   = "1504207550097260716"
     euphoria = "1510342663701004318"
     moira    = "1512927492577689620"
+    titan-ai = "1513107170533703730"
+    nova     = "1513218263885287584"
   }
 
   # @everyone role ID is always the server/guild ID in Discord

--- a/terraform/moved.tf
+++ b/terraform/moved.tf
@@ -209,3 +209,55 @@ moved {
   from = discord_channel_permission.allow_hermes["hermes-jazzlyn"]
   to   = discord_channel_permission.allow_hermes["moira"]
 }
+
+# hermes-crowlex -> titan-ai channel rename
+moved {
+  from = module.channel["hermes-crowlex"].discord_text_channel.main[0]
+  to   = module.channel["titan-ai"].discord_text_channel.main[0]
+}
+
+moved {
+  from = discord_channel_permission.deny_everyone["hermes-crowlex"]
+  to   = discord_channel_permission.deny_everyone["titan-ai"]
+}
+
+moved {
+  from = discord_channel_permission.allow_owner["hermes-crowlex"]
+  to   = discord_channel_permission.allow_owner["titan-ai"]
+}
+
+moved {
+  from = discord_channel_permission.allow_admin["hermes-crowlex"]
+  to   = discord_channel_permission.allow_admin["titan-ai"]
+}
+
+moved {
+  from = discord_channel_permission.allow_hermes["hermes-crowlex"]
+  to   = discord_channel_permission.allow_hermes["titan-ai"]
+}
+
+# hermes-techninik -> nova channel rename
+moved {
+  from = module.channel["hermes-techninik"].discord_text_channel.main[0]
+  to   = module.channel["nova"].discord_text_channel.main[0]
+}
+
+moved {
+  from = discord_channel_permission.deny_everyone["hermes-techninik"]
+  to   = discord_channel_permission.deny_everyone["nova"]
+}
+
+moved {
+  from = discord_channel_permission.allow_owner["hermes-techninik"]
+  to   = discord_channel_permission.allow_owner["nova"]
+}
+
+moved {
+  from = discord_channel_permission.allow_admin["hermes-techninik"]
+  to   = discord_channel_permission.allow_admin["nova"]
+}
+
+moved {
+  from = discord_channel_permission.allow_hermes["hermes-techninik"]
+  to   = discord_channel_permission.allow_hermes["nova"]
+}

--- a/terraform/permissions.tf
+++ b/terraform/permissions.tf
@@ -56,3 +56,19 @@ resource "discord_channel_permission" "allow_moira" {
   deny         = 0
   allow        = tonumber(local.perms_read_write_history)
 }
+
+resource "discord_channel_permission" "allow_titan_ai" {
+  channel_id   = module.channel["titan-ai"].data[0].id
+  type         = "user"
+  overwrite_id = local.user_ids["titan-ai"]
+  deny         = 0
+  allow        = tonumber(local.perms_read_write_history)
+}
+
+resource "discord_channel_permission" "allow_nova" {
+  channel_id   = module.channel["nova"].data[0].id
+  type         = "user"
+  overwrite_id = local.user_ids["nova"]
+  deny         = 0
+  allow        = tonumber(local.perms_read_write_history)
+}


### PR DESCRIPTION
Adds a new private per-user channel `nova` for techinik in the `agents` category, following the same pattern as `titan-ai`, `euphoria`, and `moira`.

Ref: tyriis/home-ops#8831

### Changes
- `data/channels/nova.yaml` — new private channel with owner `techinik`
- `data/categories/agents.yaml` — added `nova` to channels list
- `terraform/locals.tf` — added `nova` snowflake ID
- `terraform/permissions.tf` — added `allow_nova` permission entry