### PR TITLE
Standardize terraform-docs config and cleanup atlantis

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -4,7 +4,6 @@ automerge: true
 delete_source_branch_on_merge: true
 projects:
   - name: terraform-discord
-    terraform_version: v1.10.5
     dir: ./terraform
     autoplan:
       when_modified: ["*.tf", "**/*.tf", ../modules/**/*.tf, ../data/**/*.yaml]

--- a/modules/assets/png-loader/README.md
+++ b/modules/assets/png-loader/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.8 |
 
 ## Providers
 

--- a/modules/data/yaml-loader/README.md
+++ b/modules/data/yaml-loader/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.8 |
 
 ## Providers
 

--- a/modules/discord/category/README.md
+++ b/modules/discord/category/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.8 |
 | <a name="requirement_discord"></a> [discord](#requirement\_discord) | 2.7.0 |
 
 ## Providers

--- a/modules/discord/channel/README.md
+++ b/modules/discord/channel/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.8 |
 | <a name="requirement_discord"></a> [discord](#requirement\_discord) | 2.7.0 |
 
 ## Providers

--- a/modules/discord/server/README.md
+++ b/modules/discord/server/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.8 |
 | <a name="requirement_discord"></a> [discord](#requirement\_discord) | 2.7.0 |
 
 ## Providers

--- a/modules/discord/webhook/README.md
+++ b/modules/discord/webhook/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.8 |
 | <a name="requirement_discord"></a> [discord](#requirement\_discord) | 2.7.0 |
 
 ## Providers

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.8 |
 | <a name="requirement_discord"></a> [discord](#requirement\_discord) | 2.7.0 |
 | <a name="requirement_vault"></a> [vault](#requirement\_vault) | 5.10.1 |
 


### PR DESCRIPTION
- Standardize `.terraform-docs.yaml` to minimal format (terraform/ repos: indent 2)
- Remove `terraform_version` from `atlantis.yaml`
- Regenerated READMEs via terraform-docs